### PR TITLE
Retain authentication status if token cannot be refreshed

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -275,8 +275,14 @@ export class NiomonClient {
         // If the token is expiring soon (in the next 1 hour) or that it has
         // already expired, we will refresh the token now.
         console.debug('Access token is expired / expiring soon, refreshing as needed')
-        await this.refreshAccessToken(refreshToken)
-        return this.authenticationStatus(false)
+        try {
+          await this.refreshAccessToken(refreshToken)
+          return this.authenticationStatus(false)
+        } catch (err) {
+          console.error('Unable to refresh access token:', err)
+          // Do nothing, the access token could still be valid, we just can't
+          // refresh it now. The existing access token will be returned.
+        }
       }
 
       const expired = expiresAt ? expiresAt < new Date() : false
@@ -287,7 +293,7 @@ export class NiomonClient {
         expired,
       }
     } catch (err) {
-      console.warn('Unable to parse authorization response from token manager:', err)
+      console.error('Unable to parse authorization response from token manager:', err)
       return null
     }
   }


### PR DESCRIPTION
If the token cannot be refreshed for whatever reason, `loadAuthenticationStatus` returns null, which indicates an unauthenticated status. In the case when token is proactively refreshed, unexpected error can cause the user to appear logged out.